### PR TITLE
Rework options system, support length provided by struct member, fix parsing issues

### DIFF
--- a/bier/serialization/BinarySerializable.py
+++ b/bier/serialization/BinarySerializable.py
@@ -160,10 +160,7 @@ def parse_annotation(annotation: Any, options: BinarySerializableOptions) -> Typ
             value_type = parse_enum_base_type(annotation)
             return EnumNode(annotation, parse_annotation(value_type, options))
 
-    if (
-        hasattr(annotation, "__value__")
-        and get_origin_type(annotation.__value__) is custom
-    ):
+    if hasattr(annotation, "__value__"):
         return parse_annotation(
             resolve_genericalias(origin, args),
             options=options,

--- a/bier/serialization/TypeNode.py
+++ b/bier/serialization/TypeNode.py
@@ -26,6 +26,35 @@ class StaticLengthNode(TypeNode[int]):
         return 0
 
 
+@dataclass(frozen=True)
+class MemberLengthNode(TypeNode[int]):
+    """
+    Returns the value of the member with the given name.
+    """
+
+    member_name: str
+
+    def _get_member_value(self, context) -> int:
+        value = context.get(self.member_name, None)
+        assert isinstance(value, int), (
+            f"Member {self.member_name} was not an int or did not exist"
+        )
+
+        return value
+
+    def read_from(self, reader, context=None):
+        assert isinstance(context, dict), "Context was not a dictionary of values"
+        return self._get_member_value(context)
+
+    def write_to(self, value, writer, context=None):
+        expected_length = self._get_member_value(context)
+        assert value == expected_length, (
+            f"Expected {expected_length} values, got {value} values"
+        )
+
+        return 0
+
+
 @dataclass(init=False, frozen=True)
 class PrimitiveNode[T](TypeNode[T]):
     """Primitive types are directly parsable and mapped to C types.
@@ -333,7 +362,6 @@ __all__ = (
     "ClassNode",
     "StructNode",
     "BytesNode",
-    "StaticLengthNode",
     "U8Node",
     "U16Node",
     "U32Node",
@@ -347,4 +375,6 @@ __all__ = (
     "F64Node",
     "EnumNode",
     "ConvertNode",
+    "StaticLengthNode",
+    "MemberLengthNode",
 )

--- a/bier/serialization/TypeNode.py
+++ b/bier/serialization/TypeNode.py
@@ -35,7 +35,11 @@ class MemberLengthNode(TypeNode[int]):
     member_name: str
 
     def _get_member_value(self, context) -> int:
-        value = context.get(self.member_name, None) if isinstance(context, dict) else getattr(context, self.member_name)
+        value = (
+            context.get(self.member_name, None)
+            if isinstance(context, dict)
+            else getattr(context, self.member_name)
+        )
         assert isinstance(value, int), (
             f"Member {self.member_name} was not an int or did not exist"
         )

--- a/bier/serialization/TypeNode.py
+++ b/bier/serialization/TypeNode.py
@@ -35,7 +35,7 @@ class MemberLengthNode(TypeNode[int]):
     member_name: str
 
     def _get_member_value(self, context) -> int:
-        value = context.get(self.member_name, None)
+        value = context.get(self.member_name, None) if isinstance(context, dict) else getattr(context, self.member_name)
         assert isinstance(value, int), (
             f"Member {self.member_name} was not an int or did not exist"
         )
@@ -47,6 +47,7 @@ class MemberLengthNode(TypeNode[int]):
         return self._get_member_value(context)
 
     def write_to(self, value, writer, context=None):
+        # context here is an instance of the class
         expected_length = self._get_member_value(context)
         assert value == expected_length, (
             f"Expected {expected_length} values, got {value} values"

--- a/bier/serialization/__init__.py
+++ b/bier/serialization/__init__.py
@@ -9,7 +9,6 @@ from .BinarySerializable import (
 )
 from .builtin_aliases import (
     bytes_d,
-    default_length_encoding,
     list_d,
     str_d,
 )
@@ -30,9 +29,10 @@ from .builtins import (
 from .options import (
     convert,
     custom,
-    length_type,
     member,
+    prefixed_length,
     static_length,
+    member_length,
 )
 from .TypeNode import (
     ClassNode,

--- a/bier/serialization/_typing_helpers.py
+++ b/bier/serialization/_typing_helpers.py
@@ -19,6 +19,11 @@ def resolve_genericalias(origin: type, args: tuple[Any, ...]):
             f"but {len(dst_parameters)} were expected."
         )
 
+    # if there are no parameters, this is just a normal alias
+    # indexing into dst_generic will throw, we need to return the actual value
+    if len(src_parameters) == 0:
+        return dst_generic
+
     # Fast path: identical parameter order
     if src_parameters == dst_parameters:
         return dst_generic[args]

--- a/bier/serialization/builtin_aliases.py
+++ b/bier/serialization/builtin_aliases.py
@@ -1,23 +1,14 @@
-from .options import length_type, custom
+from .options import custom, length_provider
 
 # useful aliases
 
-type list_d[TType, LType: length_type] = custom[list[TType], LType]
-type str_d[T: length_type] = custom[str, T]
-type bytes_d[T: length_type] = custom[bytes, T]
-
-# option aliases
-default_length_encoding = length_type
-"""
-Used for specifying the default type to use when reading a length-providing field.
-Must be serializing an 'int' type.
-"""
+type list_d[TType, LType: length_provider] = custom[list[TType], LType]
+type str_d[T: length_provider] = custom[str, T]
+type bytes_d[T: length_provider] = custom[bytes, T]
 
 __all__ = (
     # type aliases
     "list_d",
     "str_d",
     "bytes_d",
-    # option aliases
-    "default_length_encoding",
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.8"
 classifiers = [
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Intended Audience :: Developers",
     "Programming Language :: Python",
@@ -60,3 +59,8 @@ archs = ["AMD64", "ARM64"]
 
 [tool.pyright]
 pythonVersion = "3.12"
+
+[tool.hatch.envs.default]
+features = [
+  "dev",
+]


### PR DESCRIPTION
- Skip parsing of ClassVar-annotated class members to allow for constants in class definition
- Allow parsing of regular type aliases instead of just generic ones